### PR TITLE
Fix incorrect is-decimal check

### DIFF
--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -411,7 +411,7 @@ class variant {
 
   variant(TypeKind kind) : kind_{kind}, ptr_{nullptr} {
     VELOX_CHECK(
-        !isDecimalKind(kind),
+        isDecimalKind(kind),
         "Use smallDecimal() or longDecimal() for DECIMAL values.");
   }
 
@@ -449,7 +449,7 @@ class variant {
 
   static variant null(TypeKind kind) {
     VELOX_CHECK(
-        !isDecimalKind(kind),
+        isDecimalKind(kind),
         "Use smallDecimal() or longDecimal() for DECIMAL null values.");
     return variant{kind};
   }


### PR DESCRIPTION
Fix the fallback caused by below error:
```shell
E0320 14:19:16.708627 467999 Exceptions.h:68] Line: ../.././velox/type/Variant.h:455, Function:null, Expression: !isDecimalKind(kind) Use smallDecimal() or longDecimal() for DECIMAL null values., Source: RUNTIME, ErrorCode: INVALID_STATE
```