### PR TITLE
Support null literal for decimal type

### DIFF
--- a/velox/substrait/SubstraitToVeloxExpr.cpp
+++ b/velox/substrait/SubstraitToVeloxExpr.cpp
@@ -370,8 +370,16 @@ SubstraitVeloxExprConverter::toVeloxExpr(
     case ::substrait::Expression_Literal::LiteralTypeCase::kNull: {
       auto veloxType =
           toVeloxType(subParser_->parseType(substraitLit.null())->type);
-      return std::make_shared<core::ConstantTypedExpr>(
+      if (veloxType->isShortDecimal()) {
+        return std::make_shared<core::ConstantTypedExpr>(
+            veloxType, variant::shortDecimal(std::nullopt, veloxType));
+      } else if (veloxType->isLongDecimal()) {
+        return std::make_shared<core::ConstantTypedExpr>(
+            veloxType, variant::longDecimal(std::nullopt, veloxType));
+      } else {
+        return std::make_shared<core::ConstantTypedExpr>(
           veloxType, variant::null(veloxType->kind()));
+      }
     }
     case ::substrait::Expression_Literal::LiteralTypeCase::kDate:
       return std::make_shared<core::ConstantTypedExpr>(


### PR DESCRIPTION
Fixes below error by supporting decimal null literal in SubstraitToVeloxExpr.

`
E0320 14:19:16.708627 467999 Exceptions.h:68] Line: ../.././velox/type/Variant.h:455, Function:null, Expression: !isDecimalKind(kind) Use smallDecimal() or longDecimal() for DECIMAL null values., Source: RUNTIME, ErrorCode: INVALID_STATE
`